### PR TITLE
gzip update

### DIFF
--- a/scripts/bin_pointer_limited_filechunks_shortpath.py
+++ b/scripts/bin_pointer_limited_filechunks_shortpath.py
@@ -9,6 +9,7 @@ import math
 from multiprocessing import Value
 import collections
 import os
+import gzip
 from pathlib import Path
 
 #print 'Run this script in Python 2'
@@ -29,16 +30,15 @@ chunksize = 2600000 #This is approximately the number of bytes used for 100000 l
 
 def chunkify(fname):
     fileEnd = os.path.getsize(fname)
-    with open(fname,'rb') as f: #must be binary rb
+    with gzip.open(fname,'rb') as f: #must be binary rb
         chunkEnd = f.tell()
         while True:
             chunkStart = chunkEnd
             f.seek(chunksize,1)
-            f.readline()
+            l = f.readline()
             chunkEnd = f.tell()
             yield chunkStart, chunkEnd - chunkStart
-            if chunkEnd > fileEnd:
-                break
+            if not l: break
 
 # returen the keys and values of dict (read names and number)
 def findhead_nochanges(r):
@@ -97,7 +97,7 @@ def getchunkfile(a):#(chunknum_,chunkstart_,chunksize_):
     chunkstart_ = a[1]
     chunksize_ = a[2]
     with open('Chunkfile_'+run_ID+'_'+str(chunknum_),'w') as fw:
-        with open(ovlpfile,'r') as fo: #Must be binary?
+        with gzip.open(ovlpfile,'rt') as fo: #Must be binary?
             fo.seek(chunkstart_)
             lines = fo.read(chunksize_).splitlines()
             for line in lines:
@@ -159,7 +159,7 @@ if __name__ == '__main__':
 
             linecount, matches = clusteralgorithm('Chunkfile_'+run_ID)
             if sess % threads == 100:
-                with open(ovlpfile,'r') as fo:
+                with gzip.open(ovlpfile,'rt') as fo:
                     fo.seek(sessiondict[sess][1])
                     for line in fo:
                         ln = line.split('\t')


### PR DESCRIPTION
Hi, this software is completely crazy when it comes to memory space. With 80M reads (3.7G of compressed reads), the peak disk space usage is >400G and memory usage is ~200G. The former is completely unreasonable for any kind of software, the second I guess is unavoidable since it's mostly due to minimap2. Anyway, I updated the code to allow gzip compression on the fly during the first step results and make it works during the next steps. Seems to work fine with the fast mode, I edited the code for the other mode but didn't try it. Moreover, I'm wondering if StrainXPress silently ignores minimap2 memory errors when not enough memory is provided, could be worse to investigate. It would also be good to allow and works directly with gzip compressed reads as input.